### PR TITLE
Include plist as resource in podspec

### DIFF
--- a/DDVersion.podspec
+++ b/DDVersion.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
   s.source           = { :git => "https://github.com/Dids/DDVersion.git", :tag => "1.1.1" }
   s.source_files     = 'DDVersion/*.{h,m}'
-  s.resources = "DDVersion/*.plist"
+  s.resources        = 'DDVersion/*.plist'
   
   s.platform         = :ios, '8.4'
   s.requires_arc     = true

--- a/DDVersion.podspec
+++ b/DDVersion.podspec
@@ -9,6 +9,10 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/Dids/DDVersion.git", :tag => "1.1.1" }
   s.source_files     = 'DDVersion/*.{h,m}'
   
+  s.resource_bundles = {
+    'DDVersion' => 'DDVersion/*.plist'
+  }
+  
   s.platform         = :ios, '8.4'
   s.requires_arc     = true
 end

--- a/DDVersion.podspec
+++ b/DDVersion.podspec
@@ -8,10 +8,6 @@ Pod::Spec.new do |s|
 
   s.source           = { :git => "https://github.com/Dids/DDVersion.git", :tag => "1.1.1" }
   s.source_files     = 'DDVersion/*.{h,m}'
-  
-  s.resource_bundles = {
-    'DDVersion' => "DDVersion/*.plist"
-  }
   s.resources = "DDVersion/*.plist"
   
   s.platform         = :ios, '8.4'

--- a/DDVersion.podspec
+++ b/DDVersion.podspec
@@ -10,8 +10,9 @@ Pod::Spec.new do |s|
   s.source_files     = 'DDVersion/*.{h,m}'
   
   s.resource_bundles = {
-    'DDVersion' => 'DDVersion/*.plist'
+    'DDVersion' => "DDVersion/*.plist"
   }
+  s.resources = "DDVersion/*.plist"
   
   s.platform         = :ios, '8.4'
   s.requires_arc     = true


### PR DESCRIPTION
I wasn't able to read the `plist` file without including it in `resources`. I am not sure if this is just most recent version of CocoaPods or what because this was working at some point and during upgrading a bunch of dependencies and libraries it stopped. 