### PR TITLE
Get DeviceList from bundle if framework

### DIFF
--- a/DDVersion/DDVersion.m
+++ b/DDVersion/DDVersion.m
@@ -21,7 +21,15 @@
 
 + (NSString*)deviceName
 {
+    // If compiled as static library
     NSString *deviceListFilePath = [[NSBundle mainBundle] pathForResource:@"DeviceList" ofType:@"plist"];
+    
+    // If compiled as a framework
+    if (!deviceListFilePath) {
+        NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+        deviceListFilePath = [bundle pathForResource:@"DeviceList" ofType:@"plist"];
+    }
+
     NSDictionary *deviceList = [NSDictionary dictionaryWithContentsOfFile:deviceListFilePath];
     
     NSString *result = [deviceList objectForKey:[DDVersion deviceType]];


### PR DESCRIPTION
In my podfile I have `use_frameworks!` which links in all my pods via Frameworks. As a result `DeviceList` isn't in the mainBundle. This PR checks both mainBundle as well as framework bundle.